### PR TITLE
Feature/auto chooser

### DIFF
--- a/Shuffleboard-setup.json
+++ b/Shuffleboard-setup.json
@@ -1,0 +1,220 @@
+{
+  "tabPane": [
+    {
+      "title": "SmartDashboard",
+      "autoPopulate": true,
+      "autoPopulatePrefix": "SmartDashboard/",
+      "widgetPane": {
+        "gridSize": 128.0,
+        "showGrid": true,
+        "hgap": 16.0,
+        "vgap": 16.0,
+        "titleType": 0,
+        "tiles": {
+          "0,0": {
+            "size": [
+              2,
+              1
+            ],
+            "content": {
+              "_type": "ComboBox Chooser",
+              "_source0": "network_table:///SmartDashboard/SendableChooser[0]",
+              "_title": "Auto Chooser",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "2,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/backgroundColor",
+              "_title": "Arm Sim/backgroundColor",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "3,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/x",
+              "_title": "Arm Sim/ArmPivot/x",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "4,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/y",
+              "_title": "Arm Sim/ArmPivot/y",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "5,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/Arm/angle",
+              "_title": "Arm Sim/ArmPivot/Arm/angle",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "6,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/Arm/length",
+              "_title": "Arm Sim/ArmPivot/Arm/length",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "7,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/Arm/color",
+              "_title": "Arm Sim/ArmPivot/Arm/color",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "8,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/Arm/weight",
+              "_title": "Arm Sim/ArmPivot/Arm/weight",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "9,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/ArmTower/angle",
+              "_title": "Arm Sim/ArmPivot/ArmTower/angle",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "10,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/ArmTower/length",
+              "_title": "Arm Sim/ArmPivot/ArmTower/length",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "11,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/ArmTower/color",
+              "_title": "Arm Sim/ArmPivot/ArmTower/color",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "0,1": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Arm Sim/ArmPivot/ArmTower/weight",
+              "_title": "Arm Sim/ArmPivot/ArmTower/weight",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "LiveWindow",
+      "autoPopulate": true,
+      "autoPopulatePrefix": "LiveWindow/",
+      "widgetPane": {
+        "gridSize": 128.0,
+        "showGrid": true,
+        "hgap": 16.0,
+        "vgap": 16.0,
+        "titleType": 0,
+        "tiles": {}
+      }
+    },
+    {
+      "title": "Driver Dashboard",
+      "autoPopulate": false,
+      "autoPopulatePrefix": "",
+      "widgetPane": {
+        "gridSize": 128.0,
+        "showGrid": true,
+        "hgap": 16.0,
+        "vgap": 16.0,
+        "titleType": 0,
+        "tiles": {
+          "0,0": {
+            "size": [
+              2,
+              1
+            ],
+            "content": {
+              "_type": "ComboBox Chooser",
+              "_source0": "network_table:///SmartDashboard/SendableChooser[0]",
+              "_title": "Auto Chooser",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          }
+        }
+      }
+    }
+  ],
+  "windowGeometry": {
+    "x": 0.0,
+    "y": 38.0,
+    "width": 1728.0,
+    "height": 1079.0
+  }
+}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,6 +7,8 @@ package frc.robot;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.RunCommand;
@@ -39,11 +41,19 @@ public class RobotContainer {
       new CommandXboxController(OperatorConstants.kDriverControllerPort);
   private final Joystick m_driverStick = new Joystick(OperatorConstants.JOYSTICK_PORT);
 
+  private final SendableChooser<Command> m_autoChooser = new SendableChooser<>();
+
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
     // Start Logger, and record driverstation control and joystick data
     DataLogManager.start();
     DriverStation.startDataLog(DataLogManager.getLog());
+
+    // Configure sendable chooser
+    m_autoChooser.setDefaultOption(
+        "Score high no mobility", Autos.scoreHighTier(m_drivetrain, m_endEffector, m_arm));
+    m_autoChooser.addOption("Example Command (DO NOT USE)", Autos.exampleAuto(m_exampleSubsystem));
+    SmartDashboard.putData(m_autoChooser);
     // Configure the trigger bindings
     configureBindings();
     m_drivetrain.setDefaultCommand(
@@ -139,6 +149,7 @@ public class RobotContainer {
    */
   public Command getAutonomousCommand() {
     // An example command will be run in autonomous
-    return Autos.scoreHighTier(m_drivetrain, m_endEffector, m_arm);
+    return m_autoChooser.getSelected();
+    // Autos.scoreHighTier(m_drivetrain, m_endEffector, m_arm);
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -53,6 +53,7 @@ public class RobotContainer {
     m_autoChooser.setDefaultOption(
         "Score high no mobility", Autos.scoreHighTier(m_drivetrain, m_endEffector, m_arm));
     m_autoChooser.addOption("Example Command (DO NOT USE)", Autos.exampleAuto(m_exampleSubsystem));
+    m_autoChooser.addOption("None", null);
     SmartDashboard.putData(m_autoChooser);
     // Configure the trigger bindings
     configureBindings();


### PR DESCRIPTION
Added auto chooser. Adds option onto SmartDashboard to pick which auto to run. Defaults to high score no mobility, just like in SFR, so shouldn't change behavior of robot by default. Currently the options are Score High Tier no mobility, example auto, and none. (left example in there just to demonstrate the choosing capability, once we have more than one auto we should remove it). To add options in the future, just add line ```m_autoChooser.addOption( label, command);``` to the robot constructor